### PR TITLE
feat: update README.md paths and clean up Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,12 @@
       <RepoRoot Condition=" '$(RepoRoot)' == '' OR !HasTrailingSlash('$(RepoRoot)') ">$(MSBuildThisFileDirectory)</RepoRoot>
    </PropertyGroup>
 
+   <PropertyGroup Condition="$(MSBuildProjectDirectory.Contains('src'))">
+      <PackageIcon>federation-logo.png</PackageIcon>
+      <PackageReadmeFile>README.md</PackageReadmeFile>
+   </PropertyGroup>
+
    <ItemGroup Condition="$(MSBuildProjectDirectory.Contains('src'))">
-      <None Include="$(RepoRoot)\assets\federation-logo.png" Pack="true" PackagePath="\" />
+      <None Include="$(RepoRoot)\assets\federation-logo.png" Pack="true" PackagePath="\"/>
    </ItemGroup>
 </Project>

--- a/Federation/Directory.Build.props
+++ b/Federation/Directory.Build.props
@@ -5,13 +5,8 @@
 		<RootNamespace>Wangkanai.Federation</RootNamespace>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="$(MSBuildProjectDirectory.Contains('src'))">
-		<PackageIcon>federation-logo.png</PackageIcon>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-	</PropertyGroup>
-
 	<ItemGroup Condition="$(MSBuildProjectDirectory.Contains('src'))">
-		<None Include="..\README.md" Pack="true" PackagePath="\" />
+		<None Include="$(RepoRoot)\Federation\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 
 </Project>

--- a/Identity/Directory.Build.props
+++ b/Identity/Directory.Build.props
@@ -5,16 +5,10 @@
 		<Title>Wangkanai Identity</Title>
 		<PackageTags>aspnetcore;identity;model;</PackageTags>
 		<Description>Introducing `Identity`, your essential toolkit for OpenID Connect and OAuth 2 integration in ASP.NET Core. Simplify your authentication and authorization systems with our handpicked collection of helper models. Whether for enterprise-level applications or personal projects, `Identity` offers versatility and ease-of-use. Discover Identity and take your security implementation to new heights.</Description>
-		<PackageProjectUrl>https://github.com/wangkanai/wangkanai/tree/main/Identity</PackageProjectUrl>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="$(MSBuildProjectDirectory.Contains('src'))">
-		<PackageIcon>federation-logo.png</PackageIcon>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
 
 	<ItemGroup Condition="$(MSBuildProjectDirectory.Contains('src'))">
-		<None Include="..\\README.md" Pack="true" PackagePath="\" />
+		<None Include="$(RepoRoot)\Identity\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 
 </Project>

--- a/Security/Directory.Build.props
+++ b/Security/Directory.Build.props
@@ -6,6 +6,10 @@
       <Description>Enhance your ASP.NET Core applications with Security, an extension to the native ASP.NET Core Security. This library brings advanced features for a comprehensive and proactive security solution.</Description>
    </PropertyGroup>
 
+   <ItemGroup Condition="$(MSBuildProjectDirectory.Contains('src'))">
+      <None Include="$(RepoRoot)\Security\README.md" Pack="true" PackagePath="\"/>
+   </ItemGroup>
+
    <PropertyGroup>
       <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
    </PropertyGroup>
@@ -22,14 +26,5 @@
          <BuildOutputInPackage Include="@(_ReferenceCopyLocalPaths)" TargetPath="%(_ReferenceCopyLocalPaths.DestinationSubDirectory)"/>
       </ItemGroup>
    </Target>
-
-   <PropertyGroup Condition="$(MSBuildProjectDirectory.Contains('src'))">
-      <PackageIcon>wangkanai-logo.png</PackageIcon>
-      <PackageReadmeFile>README.md</PackageReadmeFile>
-   </PropertyGroup>
-
-   <ItemGroup Condition="$(MSBuildProjectDirectory.Contains('src'))">
-      <None Include="..\README.md" Pack="true" PackagePath="\"/>
-   </ItemGroup>
 
 </Project>

--- a/Security/src/Core/PrivateNetworkPolicy.cs
+++ b/Security/src/Core/PrivateNetworkPolicy.cs
@@ -4,18 +4,18 @@ namespace Wangkanai.Security;
 
 public class PrivateNetworkPolicy
 {
-	public IReadOnlyList<IAuthorizationRequirement> Requirements { get; }
-	public IReadOnlyList<string> AuthenticationSchemes { get; }
+   public IReadOnlyList<IAuthorizationRequirement> Requirements          { get; }
+   public IReadOnlyList<string>                    AuthenticationSchemes { get; }
 
-	public PrivateNetworkPolicy(IEnumerable<IAuthorizationRequirement> requirements, IEnumerable<string> authenticationSchemes)
-	{
-		requirements.ThrowIfNull();
-		authenticationSchemes.ThrowIfNull();
+   public PrivateNetworkPolicy(IEnumerable<IAuthorizationRequirement> requirements, IEnumerable<string> authenticationSchemes)
+   {
+      requirements.ThrowIfNull();
+      authenticationSchemes.ThrowIfNull();
 
-		if (!requirements.Any())
-			throw new InvalidOperationException(SecurityResources.Exception_PrivateNetworkPolicyEmpty);
+      if (!requirements.Any())
+         throw new InvalidOperationException(SecurityResources.Exception_PrivateNetworkPolicyEmpty);
 
-		Requirements = new List<IAuthorizationRequirement>(requirements).AsReadOnly();
-		AuthenticationSchemes = new List<string>(authenticationSchemes).AsReadOnly();
-	}
+      Requirements          = new List<IAuthorizationRequirement>(requirements).AsReadOnly();
+      AuthenticationSchemes = new List<string>(authenticationSchemes).AsReadOnly();
+   }
 }


### PR DESCRIPTION
This pull request refactors how NuGet package metadata and assets (such as icons and README files) are included for the `Federation`, `Identity`, and `Security` projects. The main goal is to centralize and standardize the way these files are referenced and packaged, improving maintainability and consistency across the projects.

**Centralization and Standardization of Package Metadata and Assets:**

* Moved the `<PackageIcon>` and `<PackageReadmeFile>` properties from individual project-level `Directory.Build.props` files to the root `Directory.Build.props`, ensuring consistent package metadata for all projects under `src`. [[1]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eR39-R43) [[2]](diffhunk://#diff-8b75e58e9c5a9d031844d3b08bee2a16ca1a560eb5bc0b301bb494d62c859d37L8-R9) [[3]](diffhunk://#diff-7f9f0d4a2657774b945ad6e3eec4243ec881081c37cf958739372f45797b5422L8-R11) [[4]](diffhunk://#diff-a77a2a7b88385d4f758d8c85cb922910246446869b223741a8b4ae28e31b6cacL26-L34)
* Updated asset inclusion (`README.md` and logo files) in all affected projects to use the `$(RepoRoot)` property, ensuring correct file paths and reducing duplication or errors from relative paths. [[1]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eR39-R43) [[2]](diffhunk://#diff-8b75e58e9c5a9d031844d3b08bee2a16ca1a560eb5bc0b301bb494d62c859d37L8-R9) [[3]](diffhunk://#diff-7f9f0d4a2657774b945ad6e3eec4243ec881081c37cf958739372f45797b5422L8-R11) [[4]](diffhunk://#diff-a77a2a7b88385d4f758d8c85cb922910246446869b223741a8b4ae28e31b6cacR9-R12)
* Removed redundant or now-unnecessary property and item group definitions from the individual project `Directory.Build.props` files, as these are now handled centrally. [[1]](diffhunk://#diff-8b75e58e9c5a9d031844d3b08bee2a16ca1a560eb5bc0b301bb494d62c859d37L8-R9) [[2]](diffhunk://#diff-7f9f0d4a2657774b945ad6e3eec4243ec881081c37cf958739372f45797b5422L8-R11) [[3]](diffhunk://#diff-a77a2a7b88385d4f758d8c85cb922910246446869b223741a8b4ae28e31b6cacL26-L34)

These changes streamline the packaging process and make it easier to maintain consistent NuGet package metadata and assets across multiple projects.